### PR TITLE
Add tags about popular licenses and the Open Source Initiative

### DIFF
--- a/src/licenses/apache_2.toml
+++ b/src/licenses/apache_2.toml
@@ -1,0 +1,51 @@
+name = "apache-2.0"
+description = "Quelques informations à propos de la license \"Apache License, Version 2.0\"."
+
+[[embeds]]
+title = "Apache License, Version 2.0"
+thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
+description = """
+Approuvée en 2004 par l'Apache Software Foundation, l'**Apache License, Version 2.0** est une
+license permissive dont les conditions principales permettent la distribution de travaux de toute taille
+tout en préservant la sécurité légale pour les maintainers et les utilisateurs.
+La licence est l'une des licences les plus utilisées dans le monde de l'open-source, comptant des projets
+comme [Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/LICENSE), [Bazel](https://github.com/bazelbuild/bazel/blob/master/LICENSE)
+et [Swift](https://github.com/apple/swift/blob/main/LICENSE.txt).
+
+    ▶️️ Open Source Initiative, <https://opensource.org/licenses/Apache-2.0>.
+    ▶ Site officiel, <https://www.apache.org/licenses/LICENSE-2.0>.
+    ▶️ Choose A License, <https://choosealicense.com/licenses/apache-2.0/>.
+
+La fondation Apache recommande fortementt l'ajout d'une entête dans chaque fichier source pour
+éviter les erreurs d'utilisations de la licence par des personnes extérieures.
+
+Google recommende fortement l'utilisation de `Apache-2.0`. [*(source)*](https://github.com/google/new-project/blob/master/README.md)
+"""
+
+[[embeds.fields]]
+name = "Permissions"
+inline = true
+value = """
+👌 Utilisation commerciale
+👌 Distribution
+👌 Modification
+👌 Propriété intellectuelle
+👌 Utilisation et modification privée
+"""
+
+[[embeds.fields]]
+name = "Conditions"
+inline = true
+value = """
+❕ Une copie de la licence doit être distribuée avec le logiciel
+❕️ Les modifications apportées doivent être documentées
+"""
+
+[[embeds.fields]]
+name = "Limitations"
+inline = true
+value = """
+❌ Responsabilité
+❌ Utilisation de la marque
+❌ Garantie
+"""

--- a/src/licenses/apache_2.toml
+++ b/src/licenses/apache_2.toml
@@ -19,7 +19,7 @@ et [Swift](https://github.com/apple/swift/blob/main/LICENSE.txt).
 La fondation Apache recommande fortement l'ajout d'un en-tête dans chaque fichier source pour
 éviter les erreurs d'utilisations de la licence par des personnes extérieures.
 
-Google recommende fortement l'utilisation de `Apache-2.0`. [*(source)*](https://github.com/google/new-project/blob/master/README.md)
+Google recommande fortement l'utilisation de `Apache-2.0`. [*(source)*](https://github.com/google/new-project/blob/master/README.md)
 """
 
 [[embeds.fields]]

--- a/src/licenses/apache_2.toml
+++ b/src/licenses/apache_2.toml
@@ -1,13 +1,13 @@
 name = "apache-2.0"
-description = "Quelques informations à propos de la license Apache dans sa version 2.0."
+description = "Quelques informations à propos de la license Apache, version 2.0."
 
 [[embeds]]
-title = "Apache License, Version 2.0"
+title = "Licence Apache, version 2.0 (Apache-2.0)
 thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
 description = """
-Approuvée en 2004 par l'Apache Software Foundation, la licence Apache 2 est une
-license dite permissive dont les conditions principales permettent la distribution de travaux de toute taille
-tout en préservant la sécurité légale pour les mainteneurs et les utilisateurs.
+La licence Apache est une license dite permissive dont les conditions principales permettent
+la distribution de travaux de toute tailletout en préservant la sécurité légale pour les mainteneurs et les
+utilisateurs.
 Cete licence est l'une des licences les plus utilisées dans le monde de l'open-source, comptant des projets
 comme [Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/LICENSE), [Bazel](https://github.com/bazelbuild/bazel/blob/master/LICENSE)
 et [Swift](https://github.com/apple/swift/blob/main/LICENSE.txt).

--- a/src/licenses/apache_2.toml
+++ b/src/licenses/apache_2.toml
@@ -1,5 +1,5 @@
 name = "apache-2.0"
-description = "Quelques informations à propos de la license \"Apache License, Version 2.0\"."
+description = "Quelques informations à propos de la license Apache dans sa version 2.0."
 
 [[embeds]]
 title = "Apache License, Version 2.0"
@@ -16,7 +16,7 @@ et [Swift](https://github.com/apple/swift/blob/main/LICENSE.txt).
     ▶ Site officiel, <https://www.apache.org/licenses/LICENSE-2.0>.
     ▶️ Choose A License, <https://choosealicense.com/licenses/apache-2.0/>.
 
-La fondation Apache recommande fortementt l'ajout d'une entête dans chaque fichier source pour
+La fondation Apache recommande fortementt l'ajout d'un en-tête dans chaque fichier source pour
 éviter les erreurs d'utilisations de la licence par des personnes extérieures.
 
 Google recommende fortement l'utilisation de `Apache-2.0`. [*(source)*](https://github.com/google/new-project/blob/master/README.md)

--- a/src/licenses/apache_2.toml
+++ b/src/licenses/apache_2.toml
@@ -5,10 +5,10 @@ description = "Quelques informations à propos de la license \"Apache License, V
 title = "Apache License, Version 2.0"
 thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
 description = """
-Approuvée en 2004 par l'Apache Software Foundation, l'**Apache License, Version 2.0** est une
-license permissive dont les conditions principales permettent la distribution de travaux de toute taille
-tout en préservant la sécurité légale pour les maintainers et les utilisateurs.
-La licence est l'une des licences les plus utilisées dans le monde de l'open-source, comptant des projets
+Approuvée en 2004 par l'Apache Software Foundation, la licence Apache 2 est une
+license dite permissive dont les conditions principales permettent la distribution de travaux de toute taille
+tout en préservant la sécurité légale pour les mainteneurs et les utilisateurs.
+Cete licence est l'une des licences les plus utilisées dans le monde de l'open-source, comptant des projets
 comme [Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/LICENSE), [Bazel](https://github.com/bazelbuild/bazel/blob/master/LICENSE)
 et [Swift](https://github.com/apple/swift/blob/main/LICENSE.txt).
 

--- a/src/licenses/apache_2.toml
+++ b/src/licenses/apache_2.toml
@@ -10,7 +10,7 @@ la distribution de travaux de toute taille, tout en préservant la sécurité l�
 utilisateurs.
 Cete licence est l'une des plus utilisées dans le monde de l'open-source, comptant des projets
 comme [Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/LICENSE), [Bazel](https://github.com/bazelbuild/bazel/blob/master/LICENSE)
-et [Swift](https://github.com/apple/swift/blob/main/LICENSE.txt).
+ou [Swift](https://github.com/apple/swift/blob/main/LICENSE.txt).
 
     ▶️️ Open Source Initiative, <https://opensource.org/licenses/Apache-2.0>.
     ▶ Site officiel, <https://www.apache.org/licenses/LICENSE-2.0>.

--- a/src/licenses/apache_2.toml
+++ b/src/licenses/apache_2.toml
@@ -6,9 +6,9 @@ title = "Licence Apache, version 2.0 (Apache-2.0)"
 thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
 description = """
 La licence Apache est une license dite permissive dont les conditions principales permettent
-la distribution de travaux de toute tailletout en préservant la sécurité légale pour les mainteneurs et les
+la distribution de travaux de toute taille, tout en préservant la sécurité légale pour les mainteneurs et les
 utilisateurs.
-Cete licence est l'une des licences les plus utilisées dans le monde de l'open-source, comptant des projets
+Cete licence est l'une des plus utilisées dans le monde de l'open-source, comptant des projets
 comme [Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/LICENSE), [Bazel](https://github.com/bazelbuild/bazel/blob/master/LICENSE)
 et [Swift](https://github.com/apple/swift/blob/main/LICENSE.txt).
 
@@ -16,7 +16,7 @@ et [Swift](https://github.com/apple/swift/blob/main/LICENSE.txt).
     ▶ Site officiel, <https://www.apache.org/licenses/LICENSE-2.0>.
     ▶️ Choose A License, <https://choosealicense.com/licenses/apache-2.0/>.
 
-La fondation Apache recommande fortementt l'ajout d'un en-tête dans chaque fichier source pour
+La fondation Apache recommande fortement l'ajout d'un en-tête dans chaque fichier source pour
 éviter les erreurs d'utilisations de la licence par des personnes extérieures.
 
 Google recommende fortement l'utilisation de `Apache-2.0`. [*(source)*](https://github.com/google/new-project/blob/master/README.md)

--- a/src/licenses/apache_2.toml
+++ b/src/licenses/apache_2.toml
@@ -2,7 +2,7 @@ name = "apache-2.0"
 description = "Quelques informations à propos de la license Apache, version 2.0."
 
 [[embeds]]
-title = "Licence Apache, version 2.0 (Apache-2.0)
+title = "Licence Apache, version 2.0 (Apache-2.0)"
 thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
 description = """
 La licence Apache est une license dite permissive dont les conditions principales permettent

--- a/src/licenses/bsd_3_clause.toml
+++ b/src/licenses/bsd_3_clause.toml
@@ -2,7 +2,7 @@ name = "bsd-3-clause"
 description = "Quelques informations à propos de la license BSD à 3 clauses."
 
 [[embeds]]
-title = "Licence BSD à 3 clauses"
+title = "Licence BSD à 3 clauses (BSD-3-Clause)"
 thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
 description = """
 Aussi connu sous les noms *"Nouvelle Licence BSD"* ou *"Licence BSD Modifiée"*, la license BSD

--- a/src/licenses/bsd_3_clause.toml
+++ b/src/licenses/bsd_3_clause.toml
@@ -9,7 +9,7 @@ Aussi connu sous les noms *"Nouvelle Licence BSD"* ou *"Licence BSD Modifiée"*,
 à 3 clauses est une évolution de la célèbre licence BSD enlevant la clause publicitaire.
 Cette license est populaire dans la communauté open-source et utilisée par des projets comme
 [Flutter](https://github.com/flutter/flutter/blob/master/LICENSE), [LevelDB](https://github.com/google/leveldb/blob/master/LICENSE)
-et [Quill](https://github.com/quilljs/quill/blob/develop/LICENSE).
+ou [Quill](https://github.com/quilljs/quill/blob/develop/LICENSE).
 
     ▶️️ Open Source Initiative, <https://opensource.org/licenses/BSD-3-Clause>.
     ▶️ Choose A License, <https://choosealicense.com/licenses/bsd-3-clause/>.

--- a/src/licenses/bsd_3_clause.toml
+++ b/src/licenses/bsd_3_clause.toml
@@ -1,0 +1,41 @@
+name = "bsd-3-clause"
+description = "Quelques informations à propos de la license \"The 3-Clause BSD License\"."
+
+[[embeds]]
+title = "The 3-Clause BSD License"
+thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
+description = """
+Aussi connu sous les noms *"New BSD License"* ou *"Modified BSD License"*, la license BSD
+a 3 clauses est une évolution de la célèbre licence BSD enlevant la clause publicitaire.
+Cette license est populaire dans la communauté open-source et utilisée par des projets comme
+[Flutter](https://github.com/flutter/flutter/blob/master/LICENSE), [LevelDB](https://github.com/google/leveldb/blob/master/LICENSE)
+et [Quill](https://github.com/quilljs/quill/blob/develop/LICENSE).
+
+    ▶️️ Open Source Initiative, <https://opensource.org/licenses/BSD-3-Clause>.
+    ▶️ Choose A License, <https://choosealicense.com/licenses/bsd-3-clause/>.
+"""
+
+[[embeds.fields]]
+name = "Permissions"
+inline = true
+value = """
+👌 Utilisation commerciale
+👌 Distribution
+👌 Modification
+👌 Utilisation et modification privée
+"""
+
+[[embeds.fields]]
+name = "Conditions"
+inline = true
+value = """
+❕ Une copie de la licence doit être distribuée avec le logiciel
+"""
+
+[[embeds.fields]]
+name = "Limitations"
+inline = true
+value = """
+❌ Responsabilité
+❌ Garantie
+"""

--- a/src/licenses/bsd_3_clause.toml
+++ b/src/licenses/bsd_3_clause.toml
@@ -6,7 +6,7 @@ title = "The 3-Clause BSD License"
 thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
 description = """
 Aussi connu sous les noms *"New BSD License"* ou *"Modified BSD License"*, la license BSD
-a 3 clauses est une évolution de la célèbre licence BSD enlevant la clause publicitaire.
+à 3 clauses est une évolution de la célèbre licence BSD enlevant la clause publicitaire.
 Cette license est populaire dans la communauté open-source et utilisée par des projets comme
 [Flutter](https://github.com/flutter/flutter/blob/master/LICENSE), [LevelDB](https://github.com/google/leveldb/blob/master/LICENSE)
 et [Quill](https://github.com/quilljs/quill/blob/develop/LICENSE).

--- a/src/licenses/bsd_3_clause.toml
+++ b/src/licenses/bsd_3_clause.toml
@@ -1,11 +1,11 @@
 name = "bsd-3-clause"
-description = "Quelques informations à propos de la license \"The 3-Clause BSD License\"."
+description = "Quelques informations à propos de la license BSD à 3 clauses."
 
 [[embeds]]
-title = "The 3-Clause BSD License"
+title = "Licence BSD à 3 clauses"
 thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
 description = """
-Aussi connu sous les noms *"New BSD License"* ou *"Modified BSD License"*, la license BSD
+Aussi connu sous les noms *"Nouvelle Licence BSD"* ou *"Licence BSD Modifiée"*, la license BSD
 à 3 clauses est une évolution de la célèbre licence BSD enlevant la clause publicitaire.
 Cette license est populaire dans la communauté open-source et utilisée par des projets comme
 [Flutter](https://github.com/flutter/flutter/blob/master/LICENSE), [LevelDB](https://github.com/google/leveldb/blob/master/LICENSE)

--- a/src/licenses/gpl_3.toml
+++ b/src/licenses/gpl_3.toml
@@ -1,12 +1,12 @@
 name = "gpl-3"
-description = "Quelques informations à propos de la license \"GNU General Public License version 3\"."
+description = "Quelques informations à propos de la license \"Licence Publique Générale GNU\" dans sa version 3."
 
 [[embeds]]
 title = "GNU General Public License version 3"
 thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
 description = """
-Connue pour sa rigueur et ses critères de qualité, la licence GPLv3 fait es l'un des piliers du mouvement [GNU](https://www.gnu.org/)
-et du monde du [Free Software](https://www.fsf.org/).
+Connue pour sa rigueur et ses critères de qualité, la licence GPLv3 est l'un des piliers du mouvement [GNU](https://www.gnu.org/)
+et du monde du [Logiciel Libre](https://fr.wikipedia.org/wiki/Logiciel_libre).
 GPLv3 est la licence de choix pour de nombreux projets *"Libre"* (dans le sens libre), dont [Bash](https://git.savannah.gnu.org/cgit/bash.git/tree/COPYING)
 et [GIMP](https://gitlab.gnome.org/GNOME/gimp/-/blob/master/COPYING).
 

--- a/src/licenses/gpl_3.toml
+++ b/src/licenses/gpl_3.toml
@@ -1,8 +1,8 @@
 name = "gpl-3"
-description = "Quelques informations à propos de la license \"Licence Publique Générale GNU\" dans sa version 3."
+description = "Quelques informations à propos de la license Publique Générale GNU, version 3."
 
 [[embeds]]
-title = "GNU General Public License version 3"
+title = "Licence Publique Générale GNU, version 3 (GPL-3.0-only)"
 thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
 description = """
 Connue pour sa rigueur et ses critères de qualité, la licence GPLv3 est l'un des piliers du mouvement [GNU](https://www.gnu.org/)

--- a/src/licenses/gpl_3.toml
+++ b/src/licenses/gpl_3.toml
@@ -1,0 +1,45 @@
+name = "gpl-3"
+description = "Quelques informations à propos de la license \"GNU General Public License version 3\"."
+
+[[embeds]]
+title = "GNU General Public License version 3"
+thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
+description = """
+Connue pour sa rigueur et ses critères de qualité, la licence GPLv3 fait es l'un des piliers du mouvement [GNU](https://www.gnu.org/)
+et du monde du [Free Software](https://www.fsf.org/).
+GPLv3 est la licence de choix pour de nombreux projets *"Libre"* (dans le sens libre), dont [Bash](https://git.savannah.gnu.org/cgit/bash.git/tree/COPYING)
+et [GIMP](https://gitlab.gnome.org/GNOME/gimp/-/blob/master/COPYING).
+
+    ▶️️ Open Source Initiative, <https://opensource.org/licenses/GPL-3.0>.
+    ▶ Site officiel, <https://www.gnu.org/licenses/gpl-3.0.html>.
+    ▶️ Choose A License, <https://choosealicense.com/licenses/gpl-3.0/>.
+"""
+
+[[embeds.fields]]
+name = "Permissions"
+inline = true
+value = """
+👌 Utilisation commerciale
+👌 Distribution
+👌 Modification
+👌 Propriété intellectuelle
+👌 Utilisation et modification privée
+"""
+
+[[embeds.fields]]
+name = "Conditions"
+inline = true
+value = """
+❕ Une copie du code source doit être distribuée avec le logiciel (compilé, etc...)
+❕ Une copie de la licence doit être distribuée avec le logiciel
+❕ Toutes modifications apportées doivent être publiée sous la même licence
+❕️ Les modifications apportées doivent être documentées
+"""
+
+[[embeds.fields]]
+name = "Limitations"
+inline = true
+value = """
+❌ Responsabilité
+❌ Garantie
+"""

--- a/src/licenses/gpl_3.toml
+++ b/src/licenses/gpl_3.toml
@@ -8,7 +8,7 @@ description = """
 Connue pour sa rigueur et ses critères de qualité, la licence GPLv3 est l'un des piliers du mouvement [GNU](https://www.gnu.org/)
 et du monde du [Logiciel Libre](https://fr.wikipedia.org/wiki/Logiciel_libre).
 GPLv3 est la licence de choix pour de nombreux projets *"Libre"* (dans le sens libre), dont [Bash](https://git.savannah.gnu.org/cgit/bash.git/tree/COPYING)
-et [GIMP](https://gitlab.gnome.org/GNOME/gimp/-/blob/master/COPYING).
+ou [GIMP](https://gitlab.gnome.org/GNOME/gimp/-/blob/master/COPYING).
 
     ▶️️ Open Source Initiative, <https://opensource.org/licenses/GPL-3.0>.
     ▶ Site officiel, <https://www.gnu.org/licenses/gpl-3.0.html>.

--- a/src/licenses/mit_license.toml
+++ b/src/licenses/mit_license.toml
@@ -1,5 +1,5 @@
 name = "mit-license"
-description = "Quelques informations à propos de la license \"The MIT License\"."
+description = "Quelques informations à propos de la license \"Licence MIT\"."
 
 [[embeds]]
 title = "The MIT License"
@@ -7,8 +7,8 @@ thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
 description = """
 Simple, courte mais très efficace, la licence MIT est probablement la licence la plus utilisée. Cette dernière permet
 de protéger l'ensemble d'un projet de manière compréhensible pour tous.
-Parmi les projets sous MIT, nous pouvons trouver [.NET](https://github.com/dotnet/runtime/blob/main/LICENSE.TXT),
-[Ruby on Rails](https://github.com/rails/rails/blob/master/MIT-LICENSE) et [React](https://github.com/facebook/react).
+Parmi les projets sous MIT, nous pouvons retrouver [.NET](https://github.com/dotnet/runtime/blob/main/LICENSE.TXT),
+[Ruby on Rails](https://github.com/rails/rails/blob/master/MIT-LICENSE) ou encore [React](https://github.com/facebook/react).
 
     ▶️️ Open Source Initiative, <https://opensource.org/licenses/MIT>.
     ▶️ Choose A License, <https://choosealicense.com/licenses/mit/>.

--- a/src/licenses/mit_license.toml
+++ b/src/licenses/mit_license.toml
@@ -1,8 +1,8 @@
 name = "mit-license"
-description = "Quelques informations à propos de la license \"Licence MIT\"."
+description = "Quelques informations à propos de la license MIT."
 
 [[embeds]]
-title = "The MIT License"
+title = "Licence MIT"
 thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
 description = """
 Simple, courte mais très efficace, la licence MIT est probablement la licence la plus utilisée. Cette dernière permet

--- a/src/licenses/mit_license.toml
+++ b/src/licenses/mit_license.toml
@@ -8,7 +8,7 @@ description = """
 Simple, courte mais très efficace, la licence MIT est probablement la licence la plus utilisée. Cette dernière permet
 de protéger l'ensemble d'un projet de manière compréhensible pour tous.
 Parmi les projets sous MIT, nous pouvons retrouver [.NET](https://github.com/dotnet/runtime/blob/main/LICENSE.TXT),
-[Ruby on Rails](https://github.com/rails/rails/blob/master/MIT-LICENSE) ou encore [React](https://github.com/facebook/react).
+[Ruby on Rails](https://github.com/rails/rails/blob/master/MIT-LICENSE) ou [React](https://github.com/facebook/react).
 
     ▶️️ Open Source Initiative, <https://opensource.org/licenses/MIT>.
     ▶️ Choose A License, <https://choosealicense.com/licenses/mit/>.

--- a/src/licenses/mit_license.toml
+++ b/src/licenses/mit_license.toml
@@ -2,7 +2,7 @@ name = "mit-license"
 description = "Quelques informations à propos de la license MIT."
 
 [[embeds]]
-title = "Licence MIT"
+title = "Licence MIT (MIT)"
 thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
 description = """
 Simple, courte mais très efficace, la licence MIT est probablement la licence la plus utilisée. Cette dernière permet

--- a/src/licenses/mit_license.toml
+++ b/src/licenses/mit_license.toml
@@ -1,0 +1,42 @@
+name = "mit-license"
+description = "Quelques informations à propos de la license \"The MIT License\"."
+
+[[embeds]]
+title = "The MIT License"
+thumbnail = "https://opensource.org/files/OSI_Approved_License.png"
+description = """
+Simple, courte mais très efficace, la licence MIT est probablement la licence la plus utilisée. Cette dernière permet
+de protéger l'ensemble d'un projet de manière compréhensible pour tous.
+Parmi les projets sous MIT, nous pouvons trouver [.NET](https://github.com/dotnet/runtime/blob/main/LICENSE.TXT),
+[Ruby on Rails](https://github.com/rails/rails/blob/master/MIT-LICENSE) et [React](https://github.com/facebook/react).
+
+    ▶️️ Open Source Initiative, <https://opensource.org/licenses/MIT>.
+    ▶️ Choose A License, <https://choosealicense.com/licenses/mit/>.
+
+La licence MIT est la licence la plus utilisée pour des modules [NPM](https://npmjs.com).
+"""
+
+[[embeds.fields]]
+name = "Permissions"
+inline = true
+value = """
+👌 Utilisation commerciale
+👌 Distribution
+👌 Modification
+👌 Utilisation et modification privée
+"""
+
+[[embeds.fields]]
+name = "Conditions"
+inline = true
+value = """
+❕ Une copie de la licence doit être distribuée avec le logiciel
+"""
+
+[[embeds.fields]]
+name = "Limitations"
+inline = true
+value = """
+❌ Responsabilité
+❌ Garantie
+"""

--- a/src/licenses/opensource.toml
+++ b/src/licenses/opensource.toml
@@ -8,7 +8,7 @@ L'[Open Source Initiative (OSI)](https://opensource.org/about) est un organisme 
 de définir et de consolider les fondations de la philosophie Open Source
 en informatique.
 
-Vu la rapide croissance de la popularité du mouvement, il est
+Étant donné la rapide croissance de la popularité du mouvement, il est
 nécessaire de savoir définir le terme Open Source.
 """
 thumbnail = "https://opensource.org/files/osi_symbol_0.png"

--- a/src/licenses/opensource.toml
+++ b/src/licenses/opensource.toml
@@ -1,0 +1,68 @@
+name = "opensource"
+description = "Une description de l'innitiative Open Source."
+
+[[embeds]]
+title = "Initiative Open Source"
+description = """
+L'[Open Source Initiative (OSI)](https://opensource.org/about) est un organisme ayant pour objectif
+de définir et de consolider les fondations de la philosophie Open Source
+en informatique.
+
+Vu la rapide croissance de la popularité du mouvement, il est
+nécessaire de savoir définir le terme Open Source.
+"""
+thumbnail = "https://opensource.org/files/osi_symbol_0.png"
+
+[[embeds.fields]]
+name = "Définition de l'Open Source"
+value = """
+Le terme Open Source ne désigne pas simplement l'accès au code source, mais
+aussi aux autorisations et limitations sur la modification, redistribution et utilisation
+d'un logiciel open-source.
+
+> L'intégralité de la définition dans son format original est disponible [ici](https://opensource.org/osd).
+
+:one: **Redistribution :** une licence ne doit pas restreindre toute entité de
+vendre ou de distribuer le logiciel en tant que composant d'un logiciel plus grand (en tant que dépendance).
+Une licence ne doit pas imposer de redevances.
+
+:two: **Source :** le programme doit inclure son code source et autorisé la distribution
+de ce dernier sous forme compilé ou non. Il est aussi interdit de proposer du code
+intermédiaire (preprocessor output or translators).
+
+:three: **Modifications :** une licence doit autoriser les modifications ou les travaux
+dérivés et permettre la redistribution des modifications sous les mêmes termes
+que le logiciel original.
+
+:four: **Intégrité :** une license peut restreindre la distribution de code source modifié
+si cette dernière autorise la distribution de *"patch files"* permettant de modifier le logiciel
+lors de sa compilation. Sinon, la licence doit autoriser la distribution de modification
+tout en demandant d'utiliser un nom différent.
+
+:five: **Discriminations :** une licence ne doit pas discriminer un individu ou un groupe d'individu,
+ni restreindre une entité d'utiliser le logiciel dans un but spécifique (utilisation commerciale,
+pour la rechercher, ...).
+Une licence ne doit pas imposer l'utilisation de technologies particulières.
+
+:six: **Distribution de la Licence :** les droits spécifiés par la licence doivent s'appliquer aux entités redistribuant ou
+utilisant le logiciel.
+
+:seven: **Restrictions :** les droits exigés par une licence ne doivent pas être exclusifs
+au logiciel sous certaines conditions, les droits doivent être les mêmes, peu importe l'utilisation.
+Une licence ne doit pas placer de restrictions sur les logiciels dépendent de la source (une licence ne doit
+donc pas obliger les logiciels dépendants d'être open-source eux aussi).
+"""
+
+[[embeds.fields]]
+name = "Exemples de licences Open Source"
+value = """
+> L'intégralité des licences triées alphabétiquement peut être trouvée [ici](https://opensource.org/licenses/alphabetical).
+
+👉 [Apache License Version 2.0](https://opensource.org/licenses/Apache-2.0) *(`/tag apache-2.0`)*
+👉 [BSD 3-Clause "New" license](https://opensource.org/licenses/BSD-3-Clause) *(`/tag bsd-3-clause`)*
+👉 [BSD 2-Clause "Simplified" license](https://opensource.org/licenses/BSD-2-Clause)
+👉 [GNU General Public License (GPL)](https://opensource.org/licenses/gpl-license) *(`/tag gpl-3`)*
+👉 [GNU Library General Public License (LGPL)](https://opensource.org/licenses/lgpl-license)
+👉 [MIT license](https://opensource.org/licenses/MIT) *(`/tag mit-license`)*
+👉 [Mozilla Public License 2.0 (MPL)](https://opensource.org/licenses/MPL-2.0)
+"""


### PR DESCRIPTION
The open-source philosophy is an interesting and important concept in software engineering, yet it is still not understood correctly (or at leas not minimally) by a lot of members.
And since misusing licenses and not respecting [patent]-rights is considered a crime, it is essential to add tags that can easily provide a short but correct documentation for our members.

The following merge request adds some documentation about the [Open Source Initiative (OSI)](https://opensource.org), considered the main resource about open-source, as well as some information about popular open-source licenses, including the strong "Apache License, Version 2.0", the popular "MIT License", the reliable "BSD-3-Clause license" and the well-known "GNU General Public License, version 3.0". 